### PR TITLE
ENH Update `notice_updated` dates, sort feed by updated date, update links for preview/prod

### DIFF
--- a/_layouts/notice-index.html
+++ b/_layouts/notice-index.html
@@ -84,8 +84,7 @@ layout: default
             {{ notice.notice_rapids_version }}
           </td>
           <td>
-            {% assign updated_size = notice.notice_updated | size %}
-            {% if updated_size == 0 or notice.notice_updated == null %}
+            {% if notice.notice_updated == null or notice.notice_created == notice.notice_updated %}
               {{ notice.notice_created | date_to_long_string }}
             {% else %}
               {{ notice.notice_updated | date_to_long_string }}

--- a/_layouts/notice.html
+++ b/_layouts/notice.html
@@ -27,7 +27,7 @@ layout: default
     </tr>
     <tr>
       <td><strong>Updated</strong></td>
-      <td>{% if page.notice_updated != null %}{{ page.notice_updated | date_to_long_string }}{% else %}N/A{% endif %}</td>
+      <td>{% if notice.notice_updated != null and notice.notice_created != notice.notice_updated %}{{ page.notice_updated | date_to_long_string }}{% else %}N/A{% endif %}</td>
     </tr>
   </tbody>
 </table>

--- a/_notices/rgn0001.md
+++ b/_notices/rgn0001.md
@@ -20,6 +20,7 @@ notice_status_color: yellow
 notice_topic: Git Repo Change
 notice_rapids_version: "v0.15"
 notice_created: 2020-07-13
+# 'notice_updated' should match 'notice_created' until an update is made
 notice_updated: 2020-07-17
 ---
 

--- a/_notices/rgn0003.md
+++ b/_notices/rgn0003.md
@@ -20,7 +20,8 @@ notice_status_color: green
 notice_topic: Release Change
 notice_rapids_version: "v0.15"
 notice_created: 2020-08-05
-notice_updated:
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2020-08-05
 ---
 
 ## Overview

--- a/_notices/rsn0001.md
+++ b/_notices/rsn0001.md
@@ -20,7 +20,8 @@ notice_status_color: green
 notice_topic: Platform Support Change
 notice_rapids_version: "v0.15"
 notice_created: 2020-07-17
-notice_updated: null
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2020-07-17
 ---
 
 ## Overview

--- a/_notices/rsn0002.md
+++ b/_notices/rsn0002.md
@@ -20,7 +20,8 @@ notice_status_color: green
 notice_topic: Platform Support Change
 notice_rapids_version: "v0.14 & v0.15"
 notice_created: 2020-07-13
-notice_updated: null
+# 'notice_updated' should match 'notice_created' until an update is made
+notice_updated: 2020-07-13
 ---
 
 ## Overview

--- a/_notices/rsn0003.md
+++ b/_notices/rsn0003.md
@@ -20,6 +20,7 @@ notice_status_color: green
 notice_topic: Platform Support Change
 notice_rapids_version: "v0.15"
 notice_created: 2020-07-13
+# 'notice_updated' should match 'notice_created' until an update is made
 notice_updated: 2020-07-17
 ---
 

--- a/_notices/rsn0004.md
+++ b/_notices/rsn0004.md
@@ -20,6 +20,7 @@ notice_status_color: yellow
 notice_topic: Platform Support Change
 notice_rapids_version: "v0.15"
 notice_created: 2020-07-13
+# 'notice_updated' should match 'notice_created' until an update is made
 notice_updated: 2020-07-21
 ---
 

--- a/notices/feed.xml
+++ b/notices/feed.xml
@@ -18,8 +18,8 @@ layout:
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>
         <pubDate>{{ post.notice_created | date_to_rfc822 }}</pubDate>
-        <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
-        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
+        <link>{{ post.url | absolute_url }}</link>
+        <guid isPermaLink="true">{{ post.url | absolute_url }}</guid>
         {% for tag in post.tags %}
         <category>{{ tag | xml_escape }}</category>
         {% endfor %}

--- a/notices/feed.xml
+++ b/notices/feed.xml
@@ -12,7 +12,7 @@ layout:
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
-    {% assign notices = site.notices | sort: 'notice_created' | reverse %}
+    {% assign notices = site.notices | sort: 'notice_updated' | reverse %}
     {% for post in notices %}
       <item>
         <title>{{ post.title | xml_escape }}</title>

--- a/notices/feed.xml
+++ b/notices/feed.xml
@@ -7,8 +7,8 @@ layout:
   <channel>
     <title>{{ site.title | xml_escape }} - Notices</title>
     <description>Notices are our means to communicate and document changes in the project to contributors, core developers, users, and the community.</description>
-    <link>{{ site.url }}{{ site.baseurl }}notices</link>
-    <atom:link href="{{ "notices/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
+    <link>{% link notices/notices.md %}</link>
+    <atom:link href="{% link notices/feed.xml %}" rel="self" type="application/rss+xml"/>
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>

--- a/notices/feed.xml
+++ b/notices/feed.xml
@@ -17,7 +17,7 @@ layout:
       <item>
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>
-        <pubDate>{{ post.notice_created | date_to_rfc822 }}</pubDate>
+        <pubDate>{% if post.notice_updated == null or post.notice_created == post.notice_updated %}{{ post.notice_created | date_to_rfc822 }}{% else %}{{ post.notice_updated | date_to_rfc822 }}{% endif %}</pubDate>
         <link>{{ post.url | absolute_url }}</link>
         <guid isPermaLink="true">{{ post.url | absolute_url }}</guid>
         {% for tag in post.tags %}


### PR DESCRIPTION
Part of rapidsai/docs#112

Changes made to RSS feed links so they work on deployment previews and prod site. In addition, defined `notice_updated` for all notices to sort the feed by the listed updated date so updates are brought to the top of the feed.